### PR TITLE
 ajout AuthContext + switch sidebar selon le role

### DIFF
--- a/cloneApp.tsx
+++ b/cloneApp.tsx
@@ -1,0 +1,58 @@
+import { Routes, Route, Navigate, Outlet } from "react-router-dom";
+import Layout from "./components/squelette/layout";
+import LandingPage from "./pages/LandingPage";
+import SearchPage from "./pages/SearchPage";
+import NotificationPage from "./pages/NotificationPage";
+import UserPage from "./pages/UserPage";
+import { EventsPage } from "./pages/EventsPage";
+//import ClubPage from "./pages/ClubPage";
+import CreatePublicationPage from "./pages/CreatePublicationPage";
+import AdminPage from "./pages/AdminPage";
+import { AuthPage } from "./pages/AuthPage";
+
+import { ClasseListe } from "./pages/Admin/ClasseListe";
+import { AcademicYearsList } from "./pages/Admin/AcademicYearsList";
+import { ClasseDetail } from "./pages/Admin/ClasseDetail";
+import AdminDashboard from "./pages/Admin/AdminDashboard";
+
+//la si tu n'est pas connect" tu ne peut pas avoir acces au pages 
+const RequireAuth = () => {
+  const isAuth = localStorage.getItem("isAuthenticated");
+  return isAuth === "true" ? <Outlet /> : <Navigate to="/auth" replace />;
+};
+
+export default function App() {
+  return (
+    <Routes>
+      {/* Route pour l'authentification (sans la sidebar) */}
+      <Route path="/auth" element={<AuthPage />} />
+
+      {/* Routes principales (protégées) */}
+      <Route element={<RequireAuth />}>
+        <Route path="/" element={<Layout />}>
+          <Route index element={<Navigate to="/accueil" replace />} />
+          <Route path="accueil" element={<LandingPage />} />
+          <Route path="rechercher" element={<SearchPage />} />
+          <Route path="notifications" element={<NotificationPage />} />
+          <Route path="profil" element={<UserPage />} />
+          <Route path="evenements" element={<EventsPage />} />
+          {/* <Route path="clubs" element={<ClubPage />} /> */}
+          <Route path="creer-publication" element={<CreatePublicationPage />} />
+
+          {/* Zone Admin */}
+          <Route path="admin/dashboard" element={<AdminDashboard />} />
+          <Route path="admin" element={<AdminPage />} />
+          <Route path="annees-academiques" element={<AcademicYearsList />} />
+          <Route path="classeListe" element={<ClasseListe />} />
+          <Route path="admin/classes/:id" element={<ClasseDetail />} />
+        </Route>
+      </Route>
+
+      {/* Redirection par défaut pour les routes inconnues (s'il n'est pas connecté ira dans auth sinon redirigé par les autres routes) */}
+      <Route path="*" element={<Navigate to="/auth" replace />} />
+    </Routes>
+  );
+}
+
+
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,62 @@
+// import { Routes, Route, Navigate, Outlet } from "react-router-dom";
+// import Layout from "./components/squelette/layout";
+// import LandingPage from "./pages/LandingPage";
+// import SearchPage from "./pages/SearchPage";
+// import NotificationPage from "./pages/NotificationPage";
+// import UserPage from "./pages/UserPage";
+// import { EventsPage } from "./pages/EventsPage";
+// //import ClubPage from "./pages/ClubPage";
+// import CreatePublicationPage from "./pages/CreatePublicationPage";
+// import AdminPage from "./pages/AdminPage";
+// import { AuthPage } from "./pages/AuthPage";
+// import { ClasseListe } from "./pages/Admin/ClasseListe";
+// import { AcademicYearsList } from "./pages/Admin/AcademicYearsList";
+// import { ClasseDetail } from "./pages/Admin/ClasseDetail";
+// import AdminDashboard from "./pages/Admin/AdminDashboard";
+//
+// //la si tu n'est pas connect" tu ne peut pas avoir acces au pages
+// const RequireAuth = () => {
+//   const isAuth = localStorage.getItem("isAuthenticated");
+//   return isAuth === "true" ? <Outlet /> : <Navigate to="/auth" replace />;
+// };
+//
+// export default function App() {
+//   return (
+//     <Routes>
+//       {/* Route pour l'authentification (sans la sidebar) */}
+//       <Route path="/auth" element={<AuthPage />} />
+//
+//       {/* Routes principales (protégées) */}
+//       <Route element={<RequireAuth />}>
+//         <Route path="/" element={<Layout />}>
+//           <Route index element={<Navigate to="/accueil" replace />} />
+//           <Route path="accueil" element={<LandingPage />} />
+//           <Route path="rechercher" element={<SearchPage />} />
+//           <Route path="notifications" element={<NotificationPage />} />
+//           <Route path="profil" element={<UserPage />} />
+//           <Route path="evenements" element={<EventsPage />} />
+//           {/* <Route path="clubs" element={<ClubPage />} /> */}
+//           <Route path="creer-publication" element={<CreatePublicationPage />} />
+//
+//           {/* Zone Admin */}
+//           <Route path="admin/dashboard" element={<AdminDashboard />} />
+//           <Route path="admin" element={<AdminPage />} />
+//           <Route path="annees-academiques" element={<AcademicYearsList />} />
+//           <Route path="classeListe" element={<ClasseListe />} />
+//           <Route path="admin/classes/:id" element={<ClasseDetail />} />
+//         </Route>
+//       </Route>
+//
+//       {/* Redirection par défaut pour les routes inconnues (s'il n'est pas connecté ira dans auth sinon redirigé par les autres routes) */}
+//       <Route path="*" element={<Navigate to="/auth" replace />} />
+//     </Routes>
+//   );
+// }
+
+
+
+//juste j'ai dupliqué app et ajouter le conttexte pour me connecter sans passer par auth c tout vous pouvez supp ceci et decommenter le haut 
+
 import { Routes, Route, Navigate, Outlet } from "react-router-dom";
 import Layout from "./components/squelette/layout";
 import LandingPage from "./pages/LandingPage";
@@ -5,7 +64,7 @@ import SearchPage from "./pages/SearchPage";
 import NotificationPage from "./pages/NotificationPage";
 import UserPage from "./pages/UserPage";
 import { EventsPage } from "./pages/EventsPage";
-import ClubPage from "./pages/ClubPage";
+//import ClubPage from "./pages/ClubPage";
 import CreatePublicationPage from "./pages/CreatePublicationPage";
 import AdminPage from "./pages/AdminPage";
 import { AuthPage } from "./pages/AuthPage";
@@ -14,17 +73,22 @@ import { ClasseListe } from "./pages/Admin/ClasseListe";
 import { AcademicYearsList } from "./pages/Admin/AcademicYearsList";
 import { ClasseDetail } from "./pages/Admin/ClasseDetail";
 import AdminDashboard from "./pages/Admin/AdminDashboard";
+import { useAuth } from "./context/AuthContext";
 
-//la si tu n'est pas connect" tu ne peut pas avoir acces au pages 
+// Composant  qui utilise le contexte
 const RequireAuth = () => {
-  const isAuth = localStorage.getItem("isAuthenticated");
-  return isAuth === "true" ? <Outlet /> : <Navigate to="/auth" replace />;
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return <div className="flex items-center justify-center h-screen">Chargement...</div>;
+  }
+
+  return isAuthenticated ? <Outlet /> : <Navigate to="/auth" replace />;
 };
 
 export default function App() {
   return (
     <Routes>
-      {/* Route pour l'authentification (sans la sidebar) */}
       <Route path="/auth" element={<AuthPage />} />
 
       {/* Routes principales (protégées) */}

--- a/src/components/squelette/layout.tsx
+++ b/src/components/squelette/layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useLocation, Navigate } from "react-router-dom";
+/*import { Outlet, useLocation, Navigate } from "react-router-dom";
 import { SidebarProvider, SidebarInset } from "../ui/sidebar";
 import AppSidebar from "./appSidebar";
 import SidebarAdmin from "../../pages/Admin/SidebarAdmin";
@@ -44,6 +44,69 @@ export default function Layout() {
       <AppSidebar />
       <SidebarInset className="flex-1 min-h-screen overflow-y-auto bg-background"
         style={{ marginLeft: "16rem" }}>
+        <main className="h-full p-0">
+          <Outlet />
+        </main>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}*/
+
+/*j'ai essayé de me rendre sur /admin mais la sidebar a pas changé donc j'ai reecris le layout mais en commentant juste le haut */
+import { Outlet, useLocation, Navigate } from "react-router-dom";
+import { SidebarProvider, SidebarInset } from "../ui/sidebar";
+import AppSidebar from "./appSidebar";
+import SidebarAdmin from "../../pages/Admin/SidebarAdmin";
+import { useAuth } from "@/context/AuthContext";
+
+export default function Layout() {
+  const location = useLocation();
+  const { user, isLoading } = useAuth();
+
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-screen bg-background">
+        <span className="text-sm text-muted-foreground">Chargement...</span>
+      </div>
+    );
+  }
+
+  // si pas connecte et pas sur /auth on redirige
+  if (!user && location.pathname !== "/auth") {
+    return <Navigate to="/auth" replace />;
+  }
+
+  // chemins qui declenchent la sidebar admin
+  const isAdminPath = ["/admin", "/annees-academiques", "/classeListe", "/general"].some(
+    path => location.pathname.startsWith(path)
+  );
+
+  // redirection automatique des admins vers leur dashboard s'ils arrivent sur la racine
+  if (location.pathname === "/" && user?.role === "ADMIN") {
+    return <Navigate to="/admin" replace />;
+  }
+
+  // layout admin 
+  if (isAdminPath && user?.role === "ADMIN") {
+    return (
+      <div className="flex bg-background h-screen overflow-hidden">
+        <SidebarAdmin />
+        <main className="flex-1 overflow-y-auto">
+          <Outlet />
+        </main>
+      </div>
+    );
+  }
+
+  // layout normal
+  return (
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset
+        className="flex-1 min-h-screen overflow-y-auto bg-background"
+        style={{ marginLeft: "16rem" }}
+      >
         <main className="h-full p-0">
           <Outlet />
         </main>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,102 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { userService } from '@/services/userService';
+import type { ReadUser } from '@/types/user';
+
+interface AuthContextType {
+  user: ReadUser | null;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  logout: () => void;
+  // En mode mock 
+  enableMock: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+// Utilisateur mocké pour le développement
+const MOCK_USER: ReadUser = {
+  id: 'dev-user-id',
+  email: 'dev@local.test',
+  username: 'devuser',
+  last_name: 'Dev',
+  first_name: 'User',
+  bio: 'Développeur en test ah comment prendre pour faire ',
+  avatar_url: null,
+  sexe: 'M' as any,
+  classe: { id: 'mock-class', name: 'L2 Génie Logiciel' },
+  role: 'ADMIN',
+  executive_role: null,
+  can_post: true,
+  access_jeton_id: null,
+  is_verified: true,
+  deleted_at: null,
+  created_at: new Date().toISOString(),
+  updated_at: null,
+  last_login_at: new Date().toISOString(),
+};
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<ReadUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [useMock, setUseMock] = useState(false);
+
+  // Vérif si le mock est activé via le envlocal que j'ai creer juste pour tester 
+  const isMockEnabledByEnv = import.meta.env.DEV && import.meta.env.VITE_USE_MOCK_AUTH === 'true';
+
+  const enableMock = () => {
+    setUser(MOCK_USER);
+    setUseMock(true);
+    localStorage.setItem('isAuthenticated', 'true');
+  };
+
+  useEffect(() => {
+    const loadUser = async () => {
+      if (isMockEnabledByEnv || useMock) {
+        console.log('🚧 Mode mock auth activé');
+        setUser(MOCK_USER);
+        localStorage.setItem('isAuthenticated', 'true');
+        setIsLoading(false);
+        return;
+      }
+
+      // Sinon leger on charge le profill
+      try {
+        const userData = await userService.getCurrentUser();
+        setUser(userData);
+        localStorage.setItem('isAuthenticated', 'true');
+      } catch (error) {
+        console.error('Non authentifié:', error);
+        setUser(null);
+        localStorage.removeItem('isAuthenticated');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadUser();
+  }, [isMockEnabledByEnv, useMock]);
+
+  const logout = () => {
+    setUser(null);
+    setUseMock(false);
+    localStorage.removeItem('isAuthenticated');
+  };
+
+  const value = {
+    user,
+    isLoading,
+    isAuthenticated: !!user,
+    logout,
+    enableMock,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('message derreur pas dinspi');
+  }
+  return context;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App.tsx'
+import { AuthProvider } from '@/context/AuthContext'
 import { Toaster } from "sonner"
 
 const queryClient = new QueryClient()
@@ -12,9 +13,12 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <App />
-        {/* a ne pas toucher  */}
-        <Toaster position="top-right" />
+        {/* AuthProvider doit etre dans BrowserRouter car useAuth peut utiliser navigate */}
+        <AuthProvider>
+          <App />
+          {/* a ne pas toucher  */}
+          <Toaster position="top-right" />
+        </AuthProvider>
       </BrowserRouter>
     </QueryClientProvider>
   </StrictMode>,


### PR DESCRIPTION
j Cree AuthContext avec mode mock pour bosser sans que le back soit up j'avais un souci quand je demarrais les contenaeurs du back mais bon vous pouvez supp chez vous , aussi Switch auto actif entre SidebarAdmin et AppSidebar selon le role de l'user et VITE_USE_MOCK_AUTH=true dans .env.local pour simuler un admin en dev